### PR TITLE
Index: implement getObjects with attributesToRetrieve

### DIFF
--- a/src/main/java/com/algolia/search/saas/Index.java
+++ b/src/main/java/com/algolia/search/saas/Index.java
@@ -226,10 +226,8 @@ public class Index {
             JSONObject body = new JSONObject();
             body.put("requests", requests);
             return client.postRequest("/1/indexes/*/objects", body.toString(), false, false);
-        } catch (JSONException e) {
+        } catch (JSONException | UnsupportedEncodingException e) {
             throw new AlgoliaException(e.getMessage());
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/algolia/search/saas/Index.java
+++ b/src/main/java/com/algolia/search/saas/Index.java
@@ -226,7 +226,9 @@ public class Index {
             JSONObject body = new JSONObject();
             body.put("requests", requests);
             return client.postRequest("/1/indexes/*/objects", body.toString(), false, false);
-        } catch (JSONException | UnsupportedEncodingException e) {
+        } catch (JSONException e) {
+            throw new AlgoliaException(e.getMessage());
+        } catch (UnsupportedEncodingException e) {
             throw new AlgoliaException(e.getMessage());
         }
     }

--- a/src/test/java/com/algolia/search/saas/SimpleTest.java
+++ b/src/test/java/com/algolia/search/saas/SimpleTest.java
@@ -637,7 +637,7 @@ public class SimpleTest extends AlgoliaTest {
                 .put("name", "Los Angeles").put("objectID", "1")).put(new JSONObject()
                 .put("name", "San Francisco").put("objectID", "2")));
         index.waitTask(task.getString("taskID"));
-        List<String> objectIDs = new ArrayList<>();
+        List<String> objectIDs = new ArrayList<String>();
         objectIDs.add("1");
         objectIDs.add("2");
         JSONObject object = index.getObjects(objectIDs, Collections.singletonList("objectID"));

--- a/src/test/java/com/algolia/search/saas/SimpleTest.java
+++ b/src/test/java/com/algolia/search/saas/SimpleTest.java
@@ -632,6 +632,20 @@ public class SimpleTest extends AlgoliaTest {
     }
 
     @Test
+    public void test35bis_getObjectsWithAttr() throws AlgoliaException, JSONException {
+        JSONObject task = index.addObjects(new JSONArray().put(new JSONObject()
+                .put("name", "Los Angeles").put("objectID", "1")).put(new JSONObject()
+                .put("name", "San Francisco").put("objectID", "2")));
+        index.waitTask(task.getString("taskID"));
+        List<String> objectIDs = new ArrayList<>();
+        objectIDs.add("1");
+        objectIDs.add("2");
+        JSONObject object = index.getObjects(objectIDs, Collections.singletonList("objectID"));
+        assertEquals("The retrieved object should have only one attribute.", 1, object.getJSONArray("results").getJSONObject(0).names().length());
+        assertEquals("The retrieved object should have only one attribute.", 1, object.getJSONArray("results").getJSONObject(1).names().length());
+    }
+
+    @Test
     public void test36_deleteByQuery() throws JSONException, AlgoliaException {
         JSONObject task = index.addObjects(new JSONArray().put(new JSONObject()
                 .put("name", "Washington"))


### PR DESCRIPTION
getObjects did not expose the `attributesToRetrieve` parameter, as noticed in [algoliasearch-client-android's #129](https://github.com/algolia/algoliasearch-client-android/issues/129). 

Fixed in this PR by implementing an overloaded method and adding some unit-tests.
