### PR TITLE
Improvements from feat/WebSphere1.6

### DIFF
--- a/src/test/java/com/algolia/search/saas/NetworkTest.java
+++ b/src/test/java/com/algolia/search/saas/NetworkTest.java
@@ -29,7 +29,7 @@ public class NetworkTest {
   public void shouldHandleTimeoutsInDns() throws AlgoliaException {
     List<String> hosts = new ArrayList<String>();
     hosts.add("java-dsn.algolia.biz");
-    hosts.add(applicationID + "-1.algolianet.com");
+    hosts.add(applicationID + "-1." + APIClient.getFallbackDomain());
 
     APIClient client = new APIClient(applicationID, apiKey, hosts, hosts);
 
@@ -41,8 +41,9 @@ public class NetworkTest {
   @Test
   public void shouldHandleConnectTimeout() throws AlgoliaException {
     List<String> hosts = new ArrayList<String>();
-    hosts.add("notcp-xx-1.algolianet.com");
-    hosts.add(applicationID + "-1.algolianet.com");
+    String fallbackDomain = APIClient.getFallbackDomain();
+    hosts.add("notcp-xx-1." + fallbackDomain);
+    hosts.add(applicationID + "-1." + fallbackDomain);
 
     APIClient client = new APIClient(applicationID, apiKey, hosts, hosts);
     client.setTimeout(1000, 1000);
@@ -56,7 +57,7 @@ public class NetworkTest {
   public void shouldHandleMultipleConnectTimeout() {
     List<String> hosts = new ArrayList<String>();
     hosts.add("notcp-xx-1.algolia.net");
-    hosts.add("notcp-xx-1.algolianet.com");
+    hosts.add("notcp-xx-1." + APIClient.getFallbackDomain());
 
     APIClient client = new APIClient(applicationID, apiKey, hosts, hosts);
     client.setTimeout(1000, 1000);
@@ -91,7 +92,7 @@ public class NetworkTest {
 
     List<String> hosts = new ArrayList<String>();
     hosts.add("localhost:8080");
-    hosts.add(applicationID + "-1.algolianet.com");
+    hosts.add(applicationID + "-1." + APIClient.getFallbackDomain());
 
     APIClient client = new APIClient(applicationID, apiKey, hosts, hosts);
     client.setTimeout(1000, 1000);
@@ -101,6 +102,4 @@ public class NetworkTest {
     long end = System.currentTimeMillis() - start;
     assertTrue(end < 2 * 1000);
   }
-
-
 }

--- a/src/test/java/com/algolia/search/saas/SimpleTest.java
+++ b/src/test/java/com/algolia/search/saas/SimpleTest.java
@@ -726,7 +726,8 @@ public class SimpleTest extends AlgoliaTest {
             avgDSNQuery += System.currentTimeMillis() - current;
         }
         avgDSNQuery /= upperBound;
-        assertTrue(2.0 < firstDSNQuery / avgDSNQuery);
+        double timeFactor = firstDSNQuery / avgDSNQuery;
+        assertTrue("KeepAlive seems disabled: firstDSNQuery / avgDSNQuery = " + timeFactor + " <= 2.0", 2.0 < timeFactor);
     }
 
     @Test


### PR DESCRIPTION
Cherry-picked commits from the WebSphere1.6 compatibility branch:
- Add failure message to `keepAlive` assertions
- Use `APIClient`'s logic to determine fallback domain in tests
- Check for httpclient's version as well to determine SNI support
